### PR TITLE
[BUGFIX] Trigger docs rendering for standalone files

### DIFF
--- a/src/Service/WebHookService.php
+++ b/src/Service/WebHookService.php
@@ -148,8 +148,8 @@ class WebHookService
                 $files = array_merge($commit->added ?? [], $commit->modified ?? [], $commit->removed ?? []);
                 foreach ($files as $file) {
                     if (strpos($file, 'Documentation/') === 0
-                        || strpos($file, 'README.md') === 0
-                        || strpos($file, 'README.rst') === 0
+                        || $file === 'README.md'
+                        || $file === 'README.rst'
                     ) {
                         $triggeringChange = true;
                         break 2;

--- a/src/Service/WebHookService.php
+++ b/src/Service/WebHookService.php
@@ -147,7 +147,10 @@ class WebHookService
             foreach ($payload->commits as $commit) {
                 $files = array_merge($commit->added ?? [], $commit->modified ?? [], $commit->removed ?? []);
                 foreach ($files as $file) {
-                    if (strpos($file, 'Documentation/') === 0) {
+                    if (strpos($file, 'Documentation/') === 0
+                        || strpos($file, 'README.md') === 0
+                        || strpos($file, 'README.rst') === 0
+                    ) {
                         $triggeringChange = true;
                         break 2;
                     }


### PR DESCRIPTION
Make sure that rendering documentation is triggered for standalone
README files as well.

Currently, supplying documentation in a dedicated Documentation
directory is supported, but also using standalone README.md or
README.rst files without the Documentation directory.

For extensions, this has the advantage that the documentation
is visible immediatedly when visiting the project on the
git hoster (e.g. GitHub) and may be a better fit for extensions
with only minimal documentation.

In any case, it is recommended to add Documentation/Settings.cfg,
so that the title is generated correctly.

Related: TYPO3-Documentation/T3DocTeam#152