### PR TITLE
[TASK] Replace shortcut to `typo3/surf` documentation in `404.html`

### DIFF
--- a/legacy_hook/tests/Unit/Fixtures/Files/404.html
+++ b/legacy_hook/tests/Unit/Fixtures/Files/404.html
@@ -116,7 +116,7 @@
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="Home/Extensions.html">Extensions by Extension Key</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://docs.typo3.org/surf/">Surf for Deployment  ➜</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://docs.typo3.org/other/typo3/surf/master/en-us/">Surf for Deployment  ➜</a></li>
 <li class="toctree-l1"><a class="reference internal" href="Home/CheatSheets.html">Cheat Sheets</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://docs.typo3.org/typo3cms/Snippets/">Snippets  ➜</a></li>
 <li class="toctree-l1"><a class="reference internal" href="Home/About/Index.html">About TYPO3 Documentation</a><ul>


### PR DESCRIPTION
See TYPO3-Documentation/T3DocTeam#159 for further details.

Wait for PR TYPO3-Documentation/typo3-docs-typo3-org-resources#4 to be merged.