### PR TITLE
[BUGFIX] Symlink core checkouts for performance reasons

### DIFF
--- a/.mage.yml
+++ b/.mage.yml
@@ -49,8 +49,12 @@ magephp:
         - fs/link: { from: "../../../../shared/var/data.db", to: "var/data.db" }
         - fs/link: { from: "../../../shared/.env.local", to: ".env.local" }
         - fs/link: { from: "../../../../shared/var/git-core-split", to: "var/git-core-split" }
+        - fs/link: { from: "../../../../shared/var/git-core-split-extensions", to: "var/git-core-split-extensions" }
+        - fs/link: { from: "../../../../shared/var/git-core-split-extensions-v8", to: "var/git-core-split-extensions-v8" }
+        - fs/link: { from: "../../../../shared/var/git-core-split-extensions-v9", to: "var/git-core-split-extensions-v9" }
         - fs/link: { from: "../../../../shared/var/git-core-pr", to: "var/git-core-pr" }
         - fs/link: { from: "../../../../shared/var/git-core-split-v8", to: "var/git-core-split-v8" }
+        - fs/link: { from: "../../../../shared/var/git-core-split-v9", to: "var/git-core-split-v9" }
       on-release:
       post-release:
         - exec: { cmd: "[ -d ../../../cachetool ] || mkdir -p ../../../cachetool"}


### PR DESCRIPTION
The core release process works in two different ways:

* Splitter
  The core splitter clones the mono repository and adds each extension
  repository as a new git remote to push to.
* Tagger
  The tagger clones each extension repository into a distinguishable
  location, creates the tags and pushes them.

All of these checkouts are now configured to be in shared/var instead
of var/ of a release and get symlinked instead after deploying a new
release as core checkouts are not related to a specific intercept
release. This also improves the performance as the checkouts don't
need to be done again.