### PR TITLE
Redirects for TYPO3 explained

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -99,6 +99,28 @@ location ~ ^/surf(.*)$ {
 }
 
 # typo3/reference-coreapi
+# redirects for moved sections
+location ~ ^/m/typo3/reference-coreapi/main/ApiOverview/TypoScriptSyntax(.*) {
+    return 303 /m/typo3/reference-coreapi/main/en-us/Configuration/TypoScriptSyntax$2;
+}
+location ~ ^/m/typo3/reference-coreapi/11.5/ApiOverview/TypoScriptSyntax(.*) {
+    return 303 /m/typo3/reference-coreapi/11.5/en-us/Configuration/TypoScriptSyntax$2;
+}
+location ~ ^/m/typo3/reference-coreapi/10.4/ApiOverview/TypoScriptSyntax(.*) {
+    return 303 /m/typo3/reference-coreapi/10.4/en-us/Configuration/TypoScriptSyntax$2;
+}
+location ~ ^/m/typo3/reference-coreapi/main/en-us/ApiOverview/Hooks(.*) {
+    return 303 /m/typo3/reference-coreapi/main/en-us/Events$2;
+}
+location ~ ^/m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Hooks(.*) {
+    return 303 /m/typo3/reference-coreapi/11.5/en-us/Events$2;
+}
+location ~ ^/m/typo3/reference-coreapi/10.4/en-us/ApiOverview/Hooks(.*) {
+    return 303 /m/typo3/reference-coreapi/10.4/en-us/Events$2;
+}
+
+# typo3/reference-coreapi
+# redirect to use en-us
 location ~ ^/typo3cms/CoreApiReference/6.2(.*)$ {
     return 303 /m/typo3/reference-coreapi/6.2/en-us$1;
 }


### PR DESCRIPTION
needed after Pages where moved