### PR TITLE
[BUGFIX][DEV-1481] docs-ghiss-bridge: Limit amount of changes pushed to Github

### DIFF
--- a/src/Controller/GithubRstIssueController.php
+++ b/src/Controller/GithubRstIssueController.php
@@ -37,6 +37,10 @@ class GithubRstIssueController extends AbstractController
     {
         try {
             $pushEventInformation = new GithubPushEventForCore(json_decode($request->getContent(), true, 512, JSON_THROW_ON_ERROR));
+            if ($pushEventInformation->targetBranch !== 'main') {
+                // We do not care about backported changes
+                throw new DoNotCareException();
+            }
             $githubService->handleGithubIssuesForRstFiles($pushEventInformation, $githubChangelogToLogRepository);
         } catch (DoNotCareException $e) {
             // Hook payload could not be identified as hook that should trigger git split

--- a/src/Service/GithubService.php
+++ b/src/Service/GithubService.php
@@ -308,7 +308,7 @@ class GithubService
     private function filterRstChanges(array $files): array
     {
         return array_filter($files, static function (string $file) {
-            return str_ends_with($file, '.rst');
+            return str_ends_with($file, '.rst') && str_contains($file, 'typo3/sysext/core/Documentation/Changelog/');
         });
     }
 }

--- a/tests/Functional/Fixtures/GithubRstIssuePatchBackportRequest.php
+++ b/tests/Functional/Fixtures/GithubRstIssuePatchBackportRequest.php
@@ -17,7 +17,7 @@ return Request::create(
     [],
     [],
     '{
-      "ref": "refs/heads/main",
+      "ref": "refs/heads/11.5",
       "before": "253c42fe1e2e050539a21973b819216d7260b1a2",
       "after": "1b93464c68d398351410d871826e30066bfdbb2f",
       "created": false,
@@ -51,8 +51,6 @@ return Request::create(
           ],
           "modified": [
             "typo3/sysext/core/Classes/Configuration/ConfigurationManager.php",
-            "typo3/sysext/core/Documentation/Index.rst",
-            "typo3/sysext/rte_ckeditor/Documentation/Configuration/ConfigureTypo3.rst",
             "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
           ]
         }
@@ -82,8 +80,6 @@ return Request::create(
         ],
         "modified": [
           "typo3/sysext/core/Classes/Configuration/ConfigurationManager.php",
-          "typo3/sysext/core/Documentation/Index.rst",
-          "typo3/sysext/rte_ckeditor/Documentation/Configuration/ConfigureTypo3.rst",
           "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
         ]
       },

--- a/tests/Functional/Fixtures/GithubRstIssuePatchNoDocsChangesRequest.php
+++ b/tests/Functional/Fixtures/GithubRstIssuePatchNoDocsChangesRequest.php
@@ -44,16 +44,11 @@ return Request::create(
             "username": "maddy2101"
           },
           "added": [
-            "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
           ],
           "removed": [
-            "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
           ],
           "modified": [
-            "typo3/sysext/core/Classes/Configuration/ConfigurationManager.php",
-            "typo3/sysext/core/Documentation/Index.rst",
-            "typo3/sysext/rte_ckeditor/Documentation/Configuration/ConfigureTypo3.rst",
-            "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
+            "typo3/sysext/core/Classes/Configuration/ConfigurationManager.php"
           ]
         }
       ],
@@ -75,16 +70,11 @@ return Request::create(
           "username": "maddy2101"
         },
         "added": [
-          "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
         ],
         "removed": [
-          "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
         ],
         "modified": [
-          "typo3/sysext/core/Classes/Configuration/ConfigurationManager.php",
-          "typo3/sysext/core/Documentation/Index.rst",
-          "typo3/sysext/rte_ckeditor/Documentation/Configuration/ConfigureTypo3.rst",
-          "typo3/sysext/core/Documentation/Changelog/12.0/Feature-97326-OpenBackendPageFromAdminPanel.rst"
+          "typo3/sysext/core/Classes/Configuration/ConfigurationManager.php"
         ]
       },
       "repository": {


### PR DESCRIPTION
The hook pinged by Github when a core patch has been merged now
considers changes in the `main` branch only. Additionally, only changes
in `typo3/sysext/core/Documentation` are considered to avoid spamming
the Documentation Team's issue board with meaningless tickets.