### PR TITLE
[TASK] Redirect ViewHelperReference/ and surf/ to latest docs version

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -8,7 +8,7 @@
 #
 # Example:
 # location ~ ^/typo3cms/ViewHelperReference(.*)$ {
-#    return 303 /other/typo3/ViewHelperReference/9.5/en-us$1;
+#    return 303 /other/typo3/view-helper-reference/main/en-us$1;
 #}
 
 # Redirect master to main
@@ -84,18 +84,18 @@ location = /core-contribution {
 
 # Rewrite Fluid VH reference links to new position
 location ~ ^/typo3cms/ViewHelperReference/latest(.*)$ {
-    return 303 /other/typo3/view-helper-reference/9.5/en-us$1;
+    return 303 /other/typo3/view-helper-reference/main/en-us$1;
 }
 location ~ ^/typo3cms/ViewHelperReference(.*)$ {
-    return 303 /other/typo3/view-helper-reference/9.5/en-us$1;
+    return 303 /other/typo3/view-helper-reference/main/en-us$1;
 }
 
 # Rewrite Surf documentation links to new position
 location ~ ^/surf/latest(.*)$ {
-    return 303 /other/typo3/surf/2.0/en-us$1;
+    return 303 /other/typo3/surf/main/en-us$1;
 }
 location ~ ^/surf(.*)$ {
-    return 303 /other/typo3/surf/2.0/en-us$1;
+    return 303 /other/typo3/surf/main/en-us$1;
 }
 
 # typo3/reference-coreapi


### PR DESCRIPTION
Align ViewHelperReference/ and surf/ shortcuts at docs.typo3.org with
similar ones and redirect to the latest version of the corresponding
documentation, rather than to a specific version that becomes outdated
over time.