### PR TITLE
Move events section

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -110,13 +110,22 @@ location ~ ^/m/typo3/reference-coreapi/10.4/ApiOverview/TypoScriptSyntax(.*) {
     return 303 /m/typo3/reference-coreapi/10.4/en-us/Configuration/TypoScriptSyntax$2;
 }
 location ~ ^/m/typo3/reference-coreapi/main/en-us/ApiOverview/Hooks(.*) {
-    return 303 /m/typo3/reference-coreapi/main/en-us/Events$2;
+    return 303 /m/typo3/reference-coreapi/main/en-us/ApiOverview/Events$2;
 }
 location ~ ^/m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Hooks(.*) {
-    return 303 /m/typo3/reference-coreapi/11.5/en-us/Events$2;
+    return 303 /m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Events$2;
 }
 location ~ ^/m/typo3/reference-coreapi/10.4/en-us/ApiOverview/Hooks(.*) {
-    return 303 /m/typo3/reference-coreapi/10.4/en-us/Events$2;
+    return 303 /m/typo3/reference-coreapi/10.4/en-us/ApiOverview/Events$2;
+}
+location ~ ^/m/typo3/reference-coreapi/main/en-us/Events(.*) {
+    return 303 /m/typo3/reference-coreapi/main/en-us/ApiOverview/Events$2;
+}
+location ~ ^/m/typo3/reference-coreapi/11.5/en-us/Events(.*) {
+    return 303 /m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Events$2;
+}
+location ~ ^/m/typo3/reference-coreapi/10.4/en-us/Events(.*) {
+    return 303 /m/typo3/reference-coreapi/10.4/en-us/ApiOverview/Events$2;
 }
 
 # typo3/reference-coreapi


### PR DESCRIPTION
Redirects from https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Events/* to https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Events/*