### PR TITLE
[TASK] Remove Core API / JavaScript redirect for v11.5

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -108,8 +108,8 @@ location ~ ^/m/typo3/reference-coreapi/(main|11.5)/en-us/ApiOverview/LinkBrowser
 location ~ ^/m/typo3/reference-coreapi/(main|11.5)/en-us/ApiOverview/Internationalization(.*) {
     return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Localization$2;
 }
-location ~ ^/m/typo3/reference-coreapi/(main|11.5)/en-us/ApiOverview/JavaScript(.*) {
-    return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Backend/JavaScript$2;
+location ~ ^/m/typo3/reference-coreapi/main/en-us/ApiOverview/JavaScript(.*) {
+    return 303 /m/typo3/reference-coreapi/main/en-us/ApiOverview/Backend/JavaScript$1;
 }
 location ~ ^/m/typo3/reference-coreapi/(main|11.5)/en-us/ApiOverview/AccessControl(.*) {
     return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Backend/AccessControl$2;
@@ -124,14 +124,14 @@ location ~ ^/m/typo3/reference-coreapi/(main|11.5)/en-us/ApiOverview/UpdateWizar
     return 303 /m/typo3/reference-coreapi/$1/en-us/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards$2;
 }
 
-location ~ ^/m/typo3/reference-coreapi/(main|11.5|10.4)/en-us/TypoScriptSyntax(.*) { 
-    return 303 /m/typo3/reference-coreapi/$1/en-us/Configuration/TypoScriptSyntax$2; 
+location ~ ^/m/typo3/reference-coreapi/(main|11.5|10.4)/en-us/TypoScriptSyntax(.*) {
+    return 303 /m/typo3/reference-coreapi/$1/en-us/Configuration/TypoScriptSyntax$2;
 }
-location ~ ^/m/typo3/reference-coreapi/(main|11.5|10.4)/en-us/ApiOverview/Hooks(.*) { 
-    return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Events$2; 
+location ~ ^/m/typo3/reference-coreapi/(main|11.5|10.4)/en-us/ApiOverview/Hooks(.*) {
+    return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Events$2;
 }
-location ~ ^/m/typo3/reference-coreapi/(main|11.5|10.4)/en-us/Events(.*) { 
-    return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Events$2; 
+location ~ ^/m/typo3/reference-coreapi/(main|11.5|10.4)/en-us/Events(.*) {
+    return 303 /m/typo3/reference-coreapi/$1/en-us/ApiOverview/Events$2;
 }
 
 # typo3/reference-coreapi


### PR DESCRIPTION
The 11.5 branch still has the JavaScript documentation at the old path and should not be redirected to another location.

See:
https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/tree/11.5/Documentation/ApiOverview/JavaScript