### PR TITLE
[BUGFIX][DEV-1631] Enable `http_method_override`

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,7 +1,7 @@
 framework:
   secret: '%env(APP_SECRET)%'
   #csrf_protection: true
-  http_method_override: false
+  http_method_override: true # Required to allow "_method" fields in forms
   trusted_proxies: '%env(TRUSTED_PROXIES)%'
   trusted_headers: [ 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix' ]
 


### PR DESCRIPTION
The configuration option `http_method_override` must be enabled in order to allow overriding the target HTTP method in forms via the `_method` field.