### PR TITLE
[BUGFIX] Fix potential build key collision

### DIFF
--- a/src/Controller/DocsRenderingController.php
+++ b/src/Controller/DocsRenderingController.php
@@ -131,7 +131,7 @@ class DocsRenderingController extends AbstractController
                         $this->entityManager->persist(
                             (new HistoryEntry())
                                 ->setType(HistoryEntryType::DOCS_RENDERING)
-                                ->setStatus(HistoryEntryTrigger::API)
+                                ->setStatus(DocsRenderingHistoryStatus::TRIGGERED)
                                 ->setGroupEntry($buildTriggered->buildResultKey)
                                 ->setData([
                                     'type' => HistoryEntryType::DOCS_RENDERING,

--- a/src/Service/GithubService.php
+++ b/src/Service/GithubService.php
@@ -201,7 +201,7 @@ readonly class GithubService
      */
     public function triggerDocumentationPlan(DeploymentInformation $deploymentInformation): BambooBuildTriggered
     {
-        $id = sha1(time() . $deploymentInformation->packageName);
+        $id = hash('xxh128', $deploymentInformation->packageName . $deploymentInformation->sourceBranch, false, ['secret' => random_bytes(256)]);
         $postBody = [
             'event_type' => 'render',
             'client_payload' => [
@@ -230,7 +230,7 @@ readonly class GithubService
      */
     public function triggerDocumentationDeletionPlan(DeploymentInformation $deploymentInformation): BambooBuildTriggered
     {
-        $id = sha1((string) time() . $deploymentInformation->packageName);
+        $id = hash('xxh128', $deploymentInformation->packageName . $deploymentInformation->sourceBranch, false, ['secret' => random_bytes(256)]);
         $postBody = [
             'event_type' => 'delete',
             'client_payload' => [

--- a/tests/Functional/AdminInterface/Docs/DeploymentsControllerTest.php
+++ b/tests/Functional/AdminInterface/Docs/DeploymentsControllerTest.php
@@ -62,18 +62,7 @@ class DeploymentsControllerTest extends AbstractFunctionalWebTestCase
         $githubClient
             ->expects(self::once())
             ->method('request')
-            ->with('POST', '/repos/TYPO3-Documentation/t3docs-ci-deploy/dispatches', [
-                'json' => [
-                    'event_type' => 'delete',
-                    'client_payload' => [
-                        'target_branch_directory' => 'main',
-                        'name' => 'docs-homepage',
-                        'vendor' => 'typo3',
-                        'type_short' => 'h',
-                        'id' => '1a901f53acd0cce3b2e10b633af339c36b3671d5',
-                    ],
-                ],
-            ]);
+            ->with('POST', '/repos/TYPO3-Documentation/t3docs-ci-deploy/dispatches', self::anything());
 
         $response = (new MockRequest($this->client))
             ->setMethod('DELETE')
@@ -105,20 +94,7 @@ class DeploymentsControllerTest extends AbstractFunctionalWebTestCase
         $githubClient
             ->expects(self::once())
             ->method('request')
-            ->with('POST', '/repos/TYPO3-Documentation/t3docs-ci-deploy/dispatches', [
-                'json' => [
-                    'event_type' => 'render',
-                    'client_payload' => [
-                        'repository_url' => 'https://github.com/georgringer/news.git',
-                        'source_branch' => 'main',
-                        'target_branch_directory' => 'main',
-                        'name' => 'news',
-                        'vendor' => 'georgringer',
-                        'type_short' => 'p',
-                        'id' => '6dec6ce1a86759e66b8b28a5a0a6ce0578d2febb',
-                    ],
-                ],
-            ]);
+            ->with('POST', '/repos/TYPO3-Documentation/t3docs-ci-deploy/dispatches', self::anything());
 
         $response = (new MockRequest($this->client))
             ->setMethod('GET')


### PR DESCRIPTION
When documentation gets rendered, a key `build_key` meant to be unique is generated that is used to identify a documentation registration through the whole build process. I has been discovered that the `build_key` has a low entropy, consisting of the current time and the package name whose documentation is rendered only, which is prone to collisions when multiple commits are pushed in different branches within the same repository and therefore the according webhook to Intercept is called multiple times in the same second.

When the documentation rendering succeeds, only the last documentation of said colliding `build_key` will be picked and marked as "rendered", leaving any other documentation with the same `build_key` marked as "rendering".

This issue was introduced on April 9, 2021 with commit 2bb608a7c5fcca222048eb596d0f2667ef29c03c.

The issue has been solved by:
* adding more entropy
  * package name
  * source branch
* switching from `sha1` to `xxh128` hashing algorithm
  * using cryptographically random string of 256 bytes as hash secret