### PR TITLE
[TASK] Enable CORS for local development

### DIFF
--- a/legacy_hook/ajaxversions.php
+++ b/legacy_hook/ajaxversions.php
@@ -14,5 +14,11 @@ use App\DocumentationVersions;
 use App\ResponseEmitter;
 use GuzzleHttp\Psr7\ServerRequest;
 
+$request_origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+if (preg_match('/^http[s]?:\/\/localhost(:\d+)?$|^http[s]?:\/\/[^\/]+\.ddev\.site(:\d+)?$/', $request_origin)) {
+    // Allow requests from localhost and all domains ending with .ddev.site
+    header("Access-Control-Allow-Origin: $request_origin");
+}
+
 $response = (new DocumentationVersions(ServerRequest::fromGlobals()))->getVersions();
 new ResponseEmitter($response);

--- a/legacy_hook/versionsJson.php
+++ b/legacy_hook/versionsJson.php
@@ -14,5 +14,11 @@ use App\DocumentationVersions;
 use App\ResponseEmitter;
 use GuzzleHttp\Psr7\ServerRequest;
 
+$request_origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+if (preg_match('/^http[s]?:\/\/localhost(:\d+)?$|^http[s]?:\/\/[^\/]+\.ddev\.site(:\d+)?$/', $request_origin)) {
+    // Allow requests from localhost and all domains ending with .ddev.site
+    header("Access-Control-Allow-Origin: $request_origin");
+}
+
 $response = (new DocumentationVersions(ServerRequest::fromGlobals()))->getVersions('JSON');
 new ResponseEmitter($response);


### PR DESCRIPTION
Modifies the server configuration to allow Cross-Origin Resource Sharing (CORS) for local development environments.