### PR TITLE
[TASK] Redirect non-handled extensions to TER and remove `exceptions`

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -90,11 +90,6 @@ location ~ ^/typo3cms/ViewHelperReference(.*)$ {
     return 303 /other/typo3/view-helper-reference/main/en-us$1;
 }
 
-# Move exceptions to standard location
-location ~ ^/typo3cms/exceptions/main/en-us/(.*)$ {
-    return 303 /m/typo3/reference-exceptions/main/en-us/$1;
-}
-
 # Rewrite Surf documentation links to new position
 location ~ ^/surf/latest(.*)$ {
     return 303 /other/typo3/surf/2.0/en-us$1;
@@ -901,8 +896,16 @@ location ~ ^/typo3cms/drafts/github/TYPO3Incubator/InfrastructureGuide/Releases(
 # typo3cms/extensions/news/Index.html (no version given!) to typo3cms/extensions/news/stable/Index.html
 # stable exists in all extensions and links to the latest version
 # If there are existing versions in the path (1.2.3 or 1.2 or latest or stable or master), these are not redirected
-location ~ ^/typo3cms/extensions/([a-z,0-9,_]+)/((?!([0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+|latest|stable|master)).*) {
+location ~ ^/typo3cms/extensions/([^/]+)$ {
+    return 303 /typo3cms/extensions/$1/stable/;
+}
+location ~ ^/typo3cms/extensions/([^/]+)/((?!([0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+|latest|stable|master)).*) {
     return 303 /typo3cms/extensions/$1/stable/$2;
+}
+# Last redirect in chain - redirect all extension URLs that didn't match before to TER.
+# This is a prefix-based redirect, this is executed after all regex-based redirects in dynamic_redirects.conf.
+location /typo3cms/extensions/ {
+    rewrite ^/typo3cms/extensions/([^/]+)(/stable/?)? https://extensions.typo3.org/extension/$1 redirect;
 }
 
 #################################


### PR DESCRIPTION
This commit updates the nginx redirects configuration to redirect any extension, that has not been redirected before by the dynamic configuration to extensions.typo3.org in order to get rid of `typo3cms/extensions`.

Also, the handling for `typo3cms/exceptions` has been removed, the directory is archived on the server.

Resolves: https://app.asana.com/0/1206620330068017/1207393774643690