### PR TITLE
[TASK] Recover exception redirects

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -90,6 +90,11 @@ location ~ ^/typo3cms/ViewHelperReference(.*)$ {
     return 303 /other/typo3/view-helper-reference/main/en-us$1;
 }
 
+# Move exceptions to standard location
+location ~ ^/typo3cms/exceptions/main/en-us/(.*)$ {
+    return 301 /m/typo3/reference-exceptions/main/en-us/$1;
+}
+
 # Rewrite Surf documentation links to new position
 location ~ ^/surf/latest(.*)$ {
     return 303 /other/typo3/surf/2.0/en-us$1;


### PR DESCRIPTION
The redirects for the old exception pages have been falsely removed and are recovered now.