### PR TITLE
[TASK] Allow linkToDocs to fallback to 'main' for unknown versions

### DIFF
--- a/legacy_hook/src/DocumentationLinker.php
+++ b/legacy_hook/src/DocumentationLinker.php
@@ -102,9 +102,10 @@ use T3Docs\VersionHandling\DefaultInventories;
  */
 final readonly class DocumentationLinker
 {
+    private const MAIN_IDENTIFIER = 'main';
+
     private FilesystemAdapter $cache;
     private int $cacheTime;
-    const MAIN_IDENTIFIER = 'main';
 
     public function __construct(private ServerRequestInterface $request)
     {

--- a/legacy_hook/src/DocumentationLinker.php
+++ b/legacy_hook/src/DocumentationLinker.php
@@ -201,7 +201,7 @@ final readonly class DocumentationLinker
                         // std:confval + pagelink.html#some-entry
                         // to:
                         // pagelink.html#confval-some-entry
-                        $link = str_replace('#', '#-' . $docNodeTypeParts[1], $indexMetaData[2]);
+                        $link = str_replace('#', '#' . $docNodeTypeParts[1] . '-', $indexMetaData[2]);
                     }
                 }
             }


### PR DESCRIPTION
Follow-up of https://github.com/TYPO3GmbH/site-intercept/pull/188

Also addresses a minor bugfix in URL replacement of "#confval-xxx" which was wrongly replaced to "#-confvalxxx"