### PR TITLE
Redirect Content Blocks to main/en-us

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -926,5 +926,5 @@ location ~ ^/typo3cms/extensions/eventnews/(.*) {
 
 # contentblocks/content-blocks to friendsoftypo3/content-blocks
 location ~ ^/p/contentblocks/content-blocks/(.*) {
-    return 303 /p/friendsoftypo3/content-blocks/$2;
+    return 303 /p/friendsoftypo3/content-blocks/main/en-us/$2;
 }


### PR DESCRIPTION
The documentation returns 404 if not opened on a specific branch.