### PR TITLE
[BUGFIX] Redirect any non-main version of the Core Changelog to main

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -750,6 +750,11 @@ location ~ ^/typo3cms/extensions/core(.*) {
     return 303 /c/typo3/cms-core/main/en-us$1;
 }
 
+# Redirect for any version of the Changelog to main. We only support the main branch here
+location ~ /c/typo3/cms-core/(?!main)/en-us(.*) {
+    return 303 /c/typo3/cms-core/main/en-us$2;
+}
+
 # friendsoftypo3/adodb
 location ~ ^typo3cms/extensions/adodb/8.4.0(.*) {
     return 303 /p/friendsoftypo3/adodb/8.4/en-us$1;

--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -751,7 +751,7 @@ location ~ ^/typo3cms/extensions/core(.*) {
 }
 
 # Redirect for any version of the Changelog to main. We only support the main branch here
-location ~ /c/typo3/cms-core/(?!main)/en-us(.*) {
+location ~ /c/typo3/cms-core/(?!main)([^/]+)/en-us(.*) {
     return 303 /c/typo3/cms-core/main/en-us$2;
 }
 

--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -751,7 +751,7 @@ location ~ ^/typo3cms/extensions/core(.*) {
 }
 
 # Redirect for any version of the Changelog to main. We only support the main branch here
-location ~ /c/typo3/cms-core/(?!main)([^/]+)/en-us(.*) {
+location ~ ^/c/typo3/cms-core/(?!main)([^/]+)/en-us(.*) {
     return 303 /c/typo3/cms-core/main/en-us$2;
 }
 


### PR DESCRIPTION
As the Changelog of version main contains all other versions we only keep that one version. 

When a new tag is released the rendering of other versions is triggered (yet to be solved) and we have to delete them manually. Sometimes Google has already indexed them.