### PR TITLE
Redirect from 1.0 to main in how to document

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -105,6 +105,11 @@ location ~ ^/typo3cms/ViewHelperReference(.*)$ {
     return 303 /other/typo3/view-helper-reference/main/en-us$1;
 }
 
+# Redirect from 1.0 to main in how to document
+location ~ ^/m/typo3/docs-how-to-document/1.0/en-us/(.*) {
+    return 303 /m/typo3/docs-how-to-document/main/en-us/$1;
+}
+
 # Redirect from old rest reference to new
 location ~ ^/m/typo3/docs-how-to-document/main/en-us/WritingReST/Reference/(.*) {
     return 303 /m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/$1;


### PR DESCRIPTION
The sphinx based documentation rendering has been turned off