### PR TITLE
Go directory up if no Index.html is found

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -981,3 +981,18 @@ location ~ ^/typo3cms/extensions/eventnews/(.*) {
 location ~ ^/p/contentblocks/content-blocks/(.*) {
     return 303 /p/friendsoftypo3/content-blocks/main/en-us/$2;
 }
+
+#################################
+# Index.html redirects
+#################################
+
+# Redirect for missing Index.html
+location ~* /Index\.html$ {
+    if (!-f $request_filename) {
+        # Look for Index.html one directory up
+        rewrite ^(/.*)/Index\.html$ $1/../Index.html last;
+    }
+
+    # If nothing is found, fall back to a 404 or other behavior
+    try_files $uri =404;
+}


### PR DESCRIPTION
This prevent showing the 404 message and instead gives better results. It also prevents us from having to create orphan Index.rst files in folders that are directly integrated into menues and have no logical index.


https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Administration/Installation/Environments/Index.html

Would redirect to 

https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Administration/Installation/Index.html

Only if by going up no page is found, then the 404 is displayed. This way we can keep ppl in context

Calling a missing page directly then has the same effect like Using the version switch when the page does not exist anymore in the newer version.

For example if you switch from 

https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/Columns/Properties/Description.html to main via the version switch you are redirected to https://docs.typo3.org/m/typo3/reference-tca/main/en-us/Columns/. While if you try to call https://docs.typo3.org/m/typo3/reference-tca/main/en-us/Columns/Properties/Description.html directly you get a 404 displayed which takes you completely out of the context of what manual and version you where in and even though the description you are seeking is still available.