### PR TITLE
[BUGFIX] Redirect /Home/GettingStarted.html

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -432,6 +432,9 @@ location ~ ^/typo3cms/GettingStartedTutorial/(master|main|stable|latest)(.*) {
 location ~ ^/typo3cms/GettingStartedTutorial(.*) {
     return 303 /m/typo3/tutorial-getting-started/main/en-us$1;
 }
+location ~ ^/Home/GettingStarted.html {
+    return 303 /m/typo3/tutorial-getting-started/main/en-us/;
+}
 
 # typo3/docs-guide-render-typo3-documentation
 location ~ ^/typo3cms/RenderTYPO3DocumentationGuide/(master|main|stable|latest)(.*) {


### PR DESCRIPTION
This is used on in the Install Tool alert box

Resolves https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-GettingStarted/issues/698