### PR TITLE
Add 301 as allowed redirect and set it as default

### DIFF
--- a/src/Entity/DocsServerRedirect.php
+++ b/src/Entity/DocsServerRedirect.php
@@ -27,10 +27,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table('redirect')]
 class DocsServerRedirect
 {
+    final public const STATUS_CODE_301 = 301; // Permanent Redirect. Keep pagerank
     final public const STATUS_CODE_302 = 302; // Found
     final public const STATUS_CODE_303 = 303; // See Other
     final public const STATUS_CODE_307 = 307; // Temporary Redirect
     public static array $allowedStatusCodes = [
+        self::STATUS_CODE_301,
         self::STATUS_CODE_302,
         self::STATUS_CODE_303,
         self::STATUS_CODE_307,
@@ -61,7 +63,7 @@ class DocsServerRedirect
     private bool $isLegacy = false;
 
     #[ORM\Column(type: 'integer')]
-    private int $statusCode = self::STATUS_CODE_303;
+    private int $statusCode = self::STATUS_CODE_301;
 
     /**
      * @throws \Exception


### PR DESCRIPTION
302, 303 and 307 are all redirects for a temporary target. For most of them google pagerank will not be transferred. Maybe it will be transferred for 302, but if target is valid for a long time, which does not respect a "temporary" redirect, we meight get lost that pagerank in future, too. Would be cool to have redirect 301 onboard and by default.