### PR TITLE
[BUGFIX]: faulty redirect for syntax > index.html

### DIFF
--- a/config/nginx/redirects.conf
+++ b/config/nginx/redirects.conf
@@ -125,7 +125,7 @@ location ~ ^/m/typo3/reference-coreapi/(main|13.4|12.4)/en-us/Configuration/Typo
 }
 
 # Move HMENU special properties into data processor
-location ~ ^/m/typo3/reference-coreapi/(main|13.4)/en-us/Configuration/TypoScript/Syntax/(?!Tmenu)(.*)$ {
+location ~ ^/m/typo3/reference-coreapi/(main|13.4)/en-us/Configuration/TypoScript/Syntax/(?!Tmenu|Index\.html)(.*)$ {
     return 303 /m/typo3/reference-typoscript/$1/en-us/DataProcessing/MenuProcessor/$2;
 }
 


### PR DESCRIPTION
### Description
Currently when visiting the syntax page (syntax/index.html inside TYPO3 explained > settings & config > TypoScript)
you wil get redirect towards the explanation of `menu` part of the data processor. See also the [original issue ](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/6050) this PR is based on.

### The goal
Seeing the syntax information page as can be seen on the 12.4 version (syntax page [12.4 version](https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/Configuration/TypoScript/Syntax/Index.html))

### Scope
Main & 13.4

### understanding the change
In [this ](https://github.com/TYPO3GmbH/site-intercept/pull/213)PR the redirect was added to move HMENU special properties into dataprocessor.  the index.html falls outisde of the Tmenu regex and thus the page gets redirected.

We want to achieve that the orignal redirect keeps working and the index.html does not get redirected.
by adding a OR inside the negative lookahead we exclude the index.html from redirecting. 

### links
[negative lookahead developer mozilla](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion?utm_source=chatgpt.com)
[regex101 result with edited regex]( https://regex101.com/r/0BSjG4/2) 

### Important information
As i didn't succeed in setting up a local environment testing should still be done.
only tested it in regex101, link is in the `link` section

