### PR TITLE
[BUGFIX] Adjust cachetime and allow "/" type permalinks

### DIFF
--- a/legacy_hook/tests/Unit/PermalinksTest.php
+++ b/legacy_hook/tests/Unit/PermalinksTest.php
@@ -257,6 +257,43 @@ class PermalinksTest extends TestCase
             'georgringer-NEWS:How_To_rEwrite_Urls@10.0',
             'https://docs.typo3.org/p/georgringer/news/10.0/en-us/Tutorials/BestPractice/Routing/Index.html#how-to-rewrite-urls',
         ];
+        # slasher
+        yield 'core cms-package manual, no version, slash syntax' => [
+            'typo3/cms-seo:developer',
+            'https://docs.typo3.org/c/typo3/cms-seo/main/en-us/Developer/Index.html#developer',
+        ];
+        yield 'core cms-package manual, with number version, slash syntax' => [
+            'typo3/cms-seo:developer@13.4',
+            'https://docs.typo3.org/c/typo3/cms-seo/13.4/en-us/Developer/Index.html#developer',
+        ];
+        yield 'core cms-package manual, with stable version, slash syntax' => [
+            'typo3/cms-seo:developer@stable',
+            'https://docs.typo3.org/c/typo3/cms-seo/13.4/en-us/Developer/Index.html#developer',
+        ];
+        yield 'core cms-package manual, with oldstable version, slash syntax' => [
+            'typo3/cms-seo:developer@oldstable',
+            'https://docs.typo3.org/c/typo3/cms-seo/12.4/en-us/Developer/Index.html#developer',
+        ];
+        yield 'core cms-package manual, with dev version, slash syntax' => [
+            'typo3/cms-seo:developer@dev',
+            'https://docs.typo3.org/c/typo3/cms-seo/main/en-us/Developer/Index.html#developer',
+        ];
+        yield 'Third party docs, no version, slash syntax' => [
+            'georgringer/news:reference',
+            'https://docs.typo3.org/p/georgringer/news/main/en-us/Reference/Index.html#reference',
+        ];
+        yield 'Third party docs, 12.1 version, slash syntax' => [
+            'georgringer/news:reference@12.1',
+            'https://docs.typo3.org/p/georgringer/news/12.1/en-us/Reference/Index.html#reference',
+        ];
+        yield 'Third party docs, 10.0 version, slash syntax' => [
+            'georgringer/news:reference@10.0',
+            'https://docs.typo3.org/p/georgringer/news/10.0/en-us/Reference/Index.html#reference',
+        ];
+        yield 'Third party docs, 10.0 version, underscores, slash syntax' => [
+            'georgringer/news:how_to_rewrite_urls@10.0',
+            'https://docs.typo3.org/p/georgringer/news/10.0/en-us/Tutorials/BestPractice/Routing/Index.html#how-to-rewrite-urls',
+        ];
     }
 
     #[DataProvider('redirectWorksDataProvider')]


### PR DESCRIPTION
Unfortunately, the docs.typo3.org permalink modal popup displayed links like this:

https://docs.typo3.org/permalink/typo3/cms-form:somekey

while however the parser would expect:

https://docs.typo3.org/permalink/typo3-cms-form:somekey

So it normalized composer keys with a dash instead of a slash.

Since people may have accidentally linked to these URLs, having broken links kind of defeats the
purpose of PERMAlinks.

Thus, even though the docs rendering will now use the "typo3-cms-form" instead of "typo3/cms-form" output, this change will also parse the "other" format properly.

Additionally, the cache timeout has been lowered
from a day (86400) to 2 hours, to better recover permalink lookup failures in case of documentation errors and re-rendering.