### PR TITLE
[TASK] Improve Slack repository discovery message for better DX

### DIFF
--- a/src/Service/SlackService.php
+++ b/src/Service/SlackService.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\DocumentationJar;
+use App\Utility\DocsUtility;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Response;
@@ -34,19 +35,33 @@ readonly class SlackService
 
     public function sendRepositoryDiscoveryMessage(DocumentationJar $jar): ResponseInterface
     {
+        $repoKey = $jar->getVendor() . '/' . $jar->getName();
+        $docsLink = DocsUtility::generateLinkToDocs($jar);
+        $deploymentsUrl = 'https://intercept.typo3.com/admin/docs/deployments';
+        $webhookDocsUrl = 'https://docs.typo3.org/permalink/h2document:webhook';
+        $sourceUrl = 'https://github.com/TYPO3GmbH/site-intercept/blob/develop/src/Service/SlackService.php';
+        $avatarUrl = 'https://intercept.typo3.com/build/images/webhookavatars/default.png';
+
         $message = [
             'channel' => '#typo3-documentation',
             'username' => 'Intercept',
-            'icon_url' => 'https://intercept.typo3.com/build/images/webhookavatars/default.png',
+            'icon_url' => $avatarUrl,
             'attachments' => [
                 [
-                    'title' => 'New repository on Intercept',
-                    'title_link' => 'https://intercept.typo3.com/admin/docs/deployments',
-                    'color' => '#4682B4',
-                    'text' => 'Repository *' . $jar->getVendor() . '/' . $jar->getName() . '* was discovered.',
-                    'fallback' => 'Repository *' . $jar->getVendor() . '/' . $jar->getName() . '* was discovered.',
-                    'footer' => 'TYPO3 Intercept',
-                    'footer_icon' => 'https://intercept.typo3.com/build/images/webhookavatars/default.png',
+                    'title' => 'New extension documentation awaiting approval',
+                    'title_link' => $deploymentsUrl,
+                    'color' => '#FF8C00',
+                    'text' => "Repository *{$repoKey}* was discovered and is awaiting approval by a Documentation Team maintainer.\n\n"
+                        . ":clipboard: *What happens next:*\n"
+                        . "\u{2022} A documentation maintainer will review and approve the repository\n"
+                        . "\u{2022} Once approved, docs will be rendered and deployed to <{$docsLink}|docs.typo3.org>\n"
+                        . "\u{2022} This is handled by volunteers \u{2014} please be patient\n\n"
+                        . ":hammer_and_wrench: *Maintainers:* <{$deploymentsUrl}|Review pending deployments>\n"
+                        . ":information_source: *Extension authors:* <{$webhookDocsUrl}|How does this work?>",
+                    'fallback' => "Repository {$repoKey} is awaiting documentation approval at {$deploymentsUrl}",
+                    'footer' => "TYPO3 Intercept \u{00b7} <{$sourceUrl}|(?)>",
+                    'footer_icon' => $avatarUrl,
+                    'mrkdwn_in' => ['text'],
                 ],
             ],
         ];

--- a/tests/Unit/Service/SlackServiceTest.php
+++ b/tests/Unit/Service/SlackServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package t3g/intercept.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DocumentationJar;
+use App\Service\SlackService;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class SlackServiceTest extends TestCase
+{
+    private ?string $originalDocsLiveServer = null;
+
+    protected function setUp(): void
+    {
+        $this->originalDocsLiveServer = $_ENV['DOCS_LIVE_SERVER'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if (null === $this->originalDocsLiveServer) {
+            unset($_ENV['DOCS_LIVE_SERVER']);
+        } else {
+            $_ENV['DOCS_LIVE_SERVER'] = $this->originalDocsLiveServer;
+        }
+    }
+
+    public function testSendRepositoryDiscoveryMessageContainsExpectedPayload(): void
+    {
+        $capturedPayload = null;
+
+        $mockClient = $this->createMock(ClientInterface::class);
+        $mockClient
+            ->expects(self::once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://hooks.slack.com/test',
+                self::callback(static function (array $options) use (&$capturedPayload): bool {
+                    $capturedPayload = $options['json'] ?? null;
+
+                    return true;
+                })
+            )
+            ->willReturn(new Response());
+
+        $_ENV['DOCS_LIVE_SERVER'] = 'https://docs.typo3.org/';
+
+        $jar = new DocumentationJar();
+        $jar->setVendor('acme');
+        $jar->setName('my-extension');
+        $jar->setPackageName('acme/my-extension');
+        $jar->setTypeShort('p');
+        $jar->setTargetBranchDirectory('main');
+
+        $service = new SlackService($mockClient, 'https://hooks.slack.com/test');
+        $service->sendRepositoryDiscoveryMessage($jar);
+
+        self::assertNotNull($capturedPayload, 'Slack message payload was not captured');
+
+        // Verify channel and identity
+        self::assertSame('#typo3-documentation', $capturedPayload['channel']);
+        self::assertSame('Intercept', $capturedPayload['username']);
+
+        $attachment = $capturedPayload['attachments'][0];
+
+        // Title should indicate awaiting approval
+        self::assertStringContainsString('awaiting approval', strtolower($attachment['title']));
+
+        // Title link must point to deployments admin
+        self::assertSame('https://intercept.typo3.com/admin/docs/deployments', $attachment['title_link']);
+
+        // Fallback must mention package and deployments URL
+        self::assertStringContainsString('acme/my-extension', $attachment['fallback']);
+        self::assertStringContainsString('intercept.typo3.com/admin/docs/deployments', $attachment['fallback']);
+
+        // Text must mention the package
+        self::assertStringContainsString('acme/my-extension', $attachment['text']);
+
+        // Text must explain what happens next
+        self::assertStringContainsString('maintainer', strtolower($attachment['text']));
+        self::assertStringContainsString('volunteer', strtolower($attachment['text']));
+
+        // Must contain the specific docs link for this package
+        self::assertStringContainsString('docs.typo3.org/p/acme/my-extension/main/en-us', $attachment['text']);
+
+        // Must link to deployments admin for maintainers
+        self::assertStringContainsString('intercept.typo3.com/admin/docs/deployments', $attachment['text']);
+
+        // Must link to webhook docs for extension authors
+        self::assertStringContainsString('docs.typo3.org/permalink/h2document:webhook', $attachment['text']);
+
+        // Footer must contain source link to SlackService.php on GitHub
+        self::assertStringContainsString('github.com/TYPO3GmbH/site-intercept', $attachment['footer']);
+        self::assertStringContainsString('SlackService.php', $attachment['footer']);
+
+        // Must opt into mrkdwn rendering for the text field
+        self::assertContains('text', $attachment['mrkdwn_in']);
+    }
+}

--- a/tests/Unit/Service/SlackServiceTest.php
+++ b/tests/Unit/Service/SlackServiceTest.php
@@ -19,22 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class SlackServiceTest extends TestCase
 {
-    private ?string $originalDocsLiveServer = null;
-
-    protected function setUp(): void
-    {
-        $this->originalDocsLiveServer = $_ENV['DOCS_LIVE_SERVER'] ?? null;
-    }
-
-    protected function tearDown(): void
-    {
-        if (null === $this->originalDocsLiveServer) {
-            unset($_ENV['DOCS_LIVE_SERVER']);
-        } else {
-            $_ENV['DOCS_LIVE_SERVER'] = $this->originalDocsLiveServer;
-        }
-    }
-
     public function testSendRepositoryDiscoveryMessageContainsExpectedPayload(): void
     {
         $capturedPayload = null;


### PR DESCRIPTION
## Summary

Rewrite the "New repository discovered" Slack notification to be actionable for all three audiences:

- **Extension authors:** explains what happens next (approval → rendering → deployment), shows the specific docs URL where their documentation will appear, links to [webhook setup docs](https://docs.typo3.org/permalink/h2document:webhook)
- **Doc team maintainers:** direct [Review pending deployments](https://intercept.typo3.com/admin/docs/deployments) link to Intercept admin
- **Intercept developers:** `(?)` link in footer pointing to the [exact source file](https://github.com/TYPO3GmbH/site-intercept/blob/develop/src/Service/SlackService.php) on GitHub for source traceability

### Before (steel blue sidebar, `#4682B4`)
> [**New repository on Intercept**](https://intercept.typo3.com/admin/docs/deployments)
> Repository **vendor/package** was discovered.
>
> 🔲 _TYPO3 Intercept_

Dead end — no next steps, no explanation of approval process.

### After (orange sidebar, `#FF8C00`)
> [**New extension documentation awaiting approval**](https://intercept.typo3.com/admin/docs/deployments)
> Repository **vendor/package** was discovered and is awaiting approval by a Documentation Team maintainer.
>
> 📋 **What happens next:**
> • A documentation maintainer will review and approve the repository
> • Once approved, docs will be rendered and deployed to [docs.typo3.org/p/vendor/package/main/en-us](https://docs.typo3.org/p/vendor/package/main/en-us)
> • This is handled by volunteers — please be patient
>
> 🛠️ **Maintainers:** [Review pending deployments](https://intercept.typo3.com/admin/docs/deployments)
> ℹ️ **Extension authors:** [How does this work?](https://docs.typo3.org/permalink/h2document:webhook)
>
> 🔲 _TYPO3 Intercept · [(?)](https://github.com/TYPO3GmbH/site-intercept/blob/develop/src/Service/SlackService.php)_

### Key changes
| Aspect | Before | After |
|--------|--------|-------|
| Title | "New repository on Intercept" | "New extension documentation awaiting approval" |
| Color | Steel blue (informational) | Orange (needs action) |
| Body | One-liner, no context | Next steps, timeline expectations |
| Links | Title links to admin (implicit) | Explicit maintainer + author links |
| Docs URL | Not shown | Specific URL where docs will appear |
| Footer | `TYPO3 Intercept` | `TYPO3 Intercept · (?)` (source traceability) |
| `mrkdwn_in` | Not set | Added `['text']` (see note below) |

### Note on `mrkdwn_in`

Per the [Slack legacy attachments docs](https://api.slack.com/reference/messaging/attachments), attachment text fields are **not** formatted by default — `mrkdwn_in` is required to enable mrkdwn rendering. However, the existing message already renders `*bold*` correctly without it, suggesting incoming webhooks may behave differently. We added `mrkdwn_in` defensively since the new message relies more heavily on formatting (bullets, links, emoji). We have no test setup for actual Slack rendering, so this cannot be verified in CI.

### Motivation

Users regularly ask in `#typo3-documentation` what to do after seeing the discovery message (e.g., "do we need to do anything else to get this approved?"). The improved message answers this proactively.

### Internal review

Reviewed at https://github.com/netresearch/site-intercept/pull/1

## Test plan

- [x] `php -l` passes on both changed files
- [ ] `phpunit tests/Unit/Service/SlackServiceTest.php` passes in CI
- [ ] Review Slack message rendering (color, links, footer) in a test channel