### PR TITLE
[TASK] Centralize history logging

### DIFF
--- a/src/Controller/AdminInterface/Docs/DeploymentsController.php
+++ b/src/Controller/AdminInterface/Docs/DeploymentsController.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace App\Controller\AdminInterface\Docs;
 
-use App\Entity\HistoryEntry;
+use App\Dto\HistoryEntryDto;
 use App\Enum\DocsRenderingHistoryStatus;
 use App\Enum\DocumentationStatus;
 use App\Enum\HistoryEntryTrigger;
@@ -27,6 +27,7 @@ use App\Repository\HistoryEntryRepository;
 use App\Service\DocsService;
 use App\Service\DocumentationBuildInformationService;
 use App\Service\GithubService;
+use App\Service\HistoryService;
 use App\Service\RenderDocumentationService;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Order;
@@ -49,6 +50,7 @@ class DeploymentsController extends AbstractController
         private readonly HistoryEntryRepository $historyEntryRepository,
         private readonly DocumentationJarRepository $documentationJarRepository,
         private readonly DocsService $docsService,
+        private readonly HistoryService $historyService,
     ) {
     }
 
@@ -157,22 +159,18 @@ class DeploymentsController extends AbstractController
                 if ($user instanceof KeyCloakUser) {
                     $userIdentifier = $user->getDisplayName();
                 }
-                $entityManager->persist(
-                    (new HistoryEntry())
-                        ->setType('docsRendering')
-                        ->setStatus(DocsRenderingHistoryStatus::PACKAGE_DELETED)
-                        ->setGroupEntry($buildTriggered->buildResultKey)
-                        ->setData([
-                            'type' => HistoryEntryType::DOCS_RENDERING,
-                            'status' => DocsRenderingHistoryStatus::PACKAGE_DELETED,
-                            'triggeredBy' => HistoryEntryTrigger::WEB,
-                            'repository' => $jar->getRepositoryUrl(),
-                            'package' => $jar->getPackageName(),
-                            'bambooKey' => $buildTriggered->buildResultKey,
-                            'user' => $userIdentifier,
-                        ])
-                );
-                $entityManager->flush();
+                $this->historyService->writeHistory(new HistoryEntryDto(
+                    type: HistoryEntryType::DOCS_RENDERING,
+                    status: DocsRenderingHistoryStatus::PACKAGE_DELETED,
+                    triggeredBy: HistoryEntryTrigger::WEB,
+                    groupEntry: $buildTriggered->buildResultKey,
+                    data: [
+                        'repository' => $jar->getRepositoryUrl(),
+                        'package' => $jar->getPackageName(),
+                        'bambooKey' => $buildTriggered->buildResultKey,
+                        'user' => $userIdentifier,
+                    ]
+                ));
             }
         }
 
@@ -213,7 +211,6 @@ class DeploymentsController extends AbstractController
     #[IsGranted('ROLE_DOCUMENTATION_MAINTAINER')]
     public function renderDocs(
         Request $request,
-        EntityManagerInterface $entityManager,
         DocumentationJarRepository $documentationJarRepository,
         RenderDocumentationService $renderDocumentationService
     ): Response {
@@ -233,40 +230,32 @@ class DeploymentsController extends AbstractController
             return $this->redirectToRoute('admin_docs_deployments');
         } catch (UnsupportedWebHookRequestException $e) {
             // Hook payload could not be identified as hook that should trigger rendering
-            $entityManager->persist(
-                (new HistoryEntry())
-                    ->setType('docsRendering')
-                    ->setStatus(DocsRenderingHistoryStatus::UNSUPPORTED_HOOK)
-                    ->setData([
-                        'type' => 'docsRendering',
-                        'status' => DocsRenderingHistoryStatus::UNSUPPORTED_HOOK,
-                        'headers' => $request->headers,
-                        'payload' => $request->getContent(),
-                        'triggeredBy' => HistoryEntryTrigger::API,
-                        'exceptionCode' => $e->getCode(),
-                        'user' => $userIdentifier,
-                    ])
-            );
-            $entityManager->flush();
+            $this->historyService->writeHistory(new HistoryEntryDto(
+                type: HistoryEntryType::DOCS_RENDERING,
+                status: DocsRenderingHistoryStatus::UNSUPPORTED_HOOK,
+                triggeredBy: HistoryEntryTrigger::API,
+                data: [
+                    'headers' => $request->headers,
+                    'payload' => $request->getContent(),
+                    'exceptionCode' => $e->getCode(),
+                    'user' => $userIdentifier,
+                ]
+            ));
 
             return new Response('Invalid hook payload. See https://intercept.typo3.com for more information.', Response::HTTP_PRECONDITION_FAILED);
         } catch (DocsPackageDoNotCareBranch $e) {
-            $entityManager->persist(
-                (new HistoryEntry())
-                    ->setType(HistoryEntryType::DOCS_RENDERING)
-                    ->setStatus(DocsRenderingHistoryStatus::NO_RELEVANT_BRANCH_OR_TAG)
-                    ->setData([
-                        'type' => HistoryEntryType::DOCS_RENDERING,
-                        'status' => DocsRenderingHistoryStatus::NO_RELEVANT_BRANCH_OR_TAG,
-                        'triggeredBy' => HistoryEntryTrigger::API,
-                        'exceptionCode' => $e->getCode(),
-                        'exceptionMessage' => $e->getMessage(),
-                        'repository' => $documentationJar->getRepositoryUrl(),
-                        'sourceBranch' => $documentationJar->getBranch(),
-                        'user' => $userIdentifier,
-                    ])
-            );
-            $entityManager->flush();
+            $this->historyService->writeHistory(new HistoryEntryDto(
+                type: HistoryEntryType::DOCS_RENDERING,
+                status: DocsRenderingHistoryStatus::NO_RELEVANT_BRANCH_OR_TAG,
+                triggeredBy: HistoryEntryTrigger::API,
+                data: [
+                    'exceptionCode' => $e->getCode(),
+                    'exceptionMessage' => $e->getMessage(),
+                    'repository' => $documentationJar->getRepositoryUrl(),
+                    'sourceBranch' => $documentationJar->getBranch(),
+                    'user' => $userIdentifier,
+                ]
+            ));
 
             return new Response('Branch or tag name ignored for documentation rendering. See https://intercept.typo3.com for more information.', Response::HTTP_PRECONDITION_FAILED);
         }

--- a/src/Controller/AdminInterface/Docs/RedirectController.php
+++ b/src/Controller/AdminInterface/Docs/RedirectController.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace App\Controller\AdminInterface\Docs;
 
+use App\Dto\HistoryEntryDto;
 use App\Entity\DocsServerRedirect;
-use App\Entity\HistoryEntry;
 use App\Enum\DocsRenderingHistoryStatus;
 use App\Enum\HistoryEntryTrigger;
 use App\Enum\HistoryEntryType;
@@ -23,6 +23,7 @@ use App\Repository\DocsServerRedirectRepository;
 use App\Repository\HistoryEntryRepository;
 use App\Service\DocsServerNginxService;
 use App\Service\GithubService;
+use App\Service\HistoryService;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Order;
 use Doctrine\ORM\EntityManagerInterface;
@@ -42,6 +43,7 @@ class RedirectController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly DocsServerNginxService $nginxService,
         private readonly GithubService $githubService,
+        private readonly HistoryService $historyService,
         private readonly Security $security,
     ) {
     }
@@ -210,21 +212,17 @@ class RedirectController extends AbstractController
         if ($user instanceof KeyCloakUser) {
             $userIdentifier = $user->getDisplayName();
         }
-        $this->entityManager->persist(
-            (new HistoryEntry())
-                ->setType(HistoryEntryType::DOCS_REDIRECT)
-                ->setStatus(DocsRenderingHistoryStatus::TRIGGERED)
-                ->setGroupEntry($bambooBuildTriggered->buildResultKey)
-                ->setData([
-                    'type' => HistoryEntryType::DOCS_REDIRECT,
-                    'status' => DocsRenderingHistoryStatus::TRIGGERED,
-                    'triggeredBy' => HistoryEntryTrigger::WEB,
-                    'subType' => $triggeredBySubType,
-                    'redirect' => $redirect->toArray(),
-                    'bambooKey' => $bambooBuildTriggered->buildResultKey,
-                    'user' => $userIdentifier,
-                ])
-        );
-        $this->entityManager->flush();
+        $this->historyService->writeHistory(new HistoryEntryDto(
+            type: HistoryEntryType::DOCS_REDIRECT,
+            status: DocsRenderingHistoryStatus::TRIGGERED,
+            triggeredBy: HistoryEntryTrigger::WEB,
+            groupEntry: $bambooBuildTriggered->buildResultKey,
+            data: [
+                'subType' => $triggeredBySubType,
+                'redirect' => $redirect->toArray(),
+                'bambooKey' => $bambooBuildTriggered->buildResultKey,
+                'user' => $userIdentifier,
+            ]
+        ));
     }
 }

--- a/src/Controller/DocsRenderingController.php
+++ b/src/Controller/DocsRenderingController.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Dto\HistoryEntryDto;
 use App\Entity\DocumentationJar;
-use App\Entity\HistoryEntry;
 use App\Enum\DocsRenderingHistoryStatus;
 use App\Enum\DocumentationStatus;
 use App\Enum\HistoryEntryTrigger;
@@ -30,9 +30,9 @@ use App\Exception\UnsupportedWebHookRequestException;
 use App\Repository\RepositoryBlacklistEntryRepository;
 use App\Service\DocumentationBuildInformationService;
 use App\Service\GithubService;
+use App\Service\HistoryService;
 use App\Service\MailService;
 use App\Service\WebHookService;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,17 +46,13 @@ use T3G\Bundle\Keycloak\Security\KeyCloakUser;
  */
 class DocsRenderingController extends AbstractController
 {
-    public function __construct(
-        private readonly EntityManagerInterface $entityManager
-    ) {
-    }
-
     #[Route(path: '/docs', name: 'docs_to_bamboo')]
     #[Route(path: '/', name: 'docs_hook_to_bamboo', host: 'docs-hook.typo3.org')]
     public function index(
         Request $request,
         GithubService $githubService,
         WebHookService $webhookService,
+        HistoryService $historyService,
         DocumentationBuildInformationService $documentationBuildInformationService,
         RepositoryBlacklistEntryRepository $repositoryBlacklistEntryRepository,
         LoggerInterface $logger,
@@ -78,21 +74,17 @@ class DocsRenderingController extends AbstractController
 
                 try {
                     if ($repositoryBlacklistEntryRepository->isBlacklisted($pushEvent->getRepositoryUrl())) {
-                        $this->entityManager->persist(
-                            (new HistoryEntry())
-                                ->setType(HistoryEntryType::DOCS_RENDERING)
-                                ->setStatus(DocsRenderingHistoryStatus::BLACKLISTED)
-                                ->setData([
-                                    'type' => HistoryEntryType::DOCS_RENDERING,
-                                    'status' => DocsRenderingHistoryStatus::BLACKLISTED,
-                                    'triggeredBy' => HistoryEntryTrigger::API,
-                                    'repository' => $pushEvent->getRepositoryUrl(),
-                                    'composerFile' => $pushEvent->getUrlToComposerFile(),
-                                    'payload' => $request->getContent(),
-                                    'user' => $userIdentifier,
-                                ])
-                        );
-                        $this->entityManager->flush();
+                        $historyService->writeHistory(new HistoryEntryDto(
+                            type: HistoryEntryType::DOCS_RENDERING,
+                            status: DocsRenderingHistoryStatus::BLACKLISTED,
+                            triggeredBy: HistoryEntryTrigger::API,
+                            data: [
+                                'repository' => $pushEvent->getRepositoryUrl(),
+                                'composerFile' => $pushEvent->getUrlToComposerFile(),
+                                'payload' => $request->getContent(),
+                                'user' => $userIdentifier,
+                            ]
+                        ));
                         continue;
                     }
                     $buildInformation = $documentationBuildInformationService->generateBuildInformation($pushEvent, $composerAsObject);
@@ -104,22 +96,18 @@ class DocsRenderingController extends AbstractController
                     // an older build finishes after a younger triggered build which would overwrite the result af the later build.
                     if (DocumentationStatus::STATUS_RENDERING === $documentationJar->getStatus()) {
                         $documentationBuildInformationService->updateReRenderNeeded($documentationJar, true);
-                        $this->entityManager->persist(
-                            (new HistoryEntry())
-                                ->setType(HistoryEntryType::DOCS_RENDERING)
-                                ->setStatus(DocsRenderingHistoryStatus::RE_RENDER_NEEDED)
-                                ->setData([
-                                    'type' => HistoryEntryType::DOCS_RENDERING,
-                                    'status' => DocsRenderingHistoryStatus::RE_RENDER_NEEDED,
-                                    'triggeredBy' => HistoryEntryTrigger::API,
-                                    'repository' => $buildInformation->repositoryUrl,
-                                    'package' => $buildInformation->packageName,
-                                    'sourceBranch' => $buildInformation->sourceBranch,
-                                    'targetBranch' => $buildInformation->targetBranchDirectory,
-                                    'user' => $userIdentifier,
-                                ])
-                        );
-                        $this->entityManager->flush();
+                        $historyService->writeHistory(new HistoryEntryDto(
+                            type: HistoryEntryType::DOCS_RENDERING,
+                            status: DocsRenderingHistoryStatus::RE_RENDER_NEEDED,
+                            triggeredBy: HistoryEntryTrigger::API,
+                            data: [
+                                'repository' => $buildInformation->repositoryUrl,
+                                'package' => $buildInformation->packageName,
+                                'sourceBranch' => $buildInformation->sourceBranch,
+                                'targetBranch' => $buildInformation->targetBranchDirectory,
+                                'user' => $userIdentifier,
+                            ]
+                        ));
                     } elseif (!$documentationJar->isApproved()) {
                         $logger->info('Repository present, but not approved. Do nothing.', [$documentationJar]);
                     } else {
@@ -129,145 +117,117 @@ class DocsRenderingController extends AbstractController
                             $documentationJar->setReRenderNeeded(false);
                             $documentationJar->setBuildKey($buildTriggered->buildResultKey);
                         });
-                        $this->entityManager->persist(
-                            (new HistoryEntry())
-                                ->setType(HistoryEntryType::DOCS_RENDERING)
-                                ->setStatus(DocsRenderingHistoryStatus::TRIGGERED)
-                                ->setGroupEntry($buildTriggered->buildResultKey)
-                                ->setData([
-                                    'type' => HistoryEntryType::DOCS_RENDERING,
-                                    'status' => DocsRenderingHistoryStatus::TRIGGERED,
-                                    'triggeredBy' => HistoryEntryTrigger::API,
-                                    'repository' => $buildInformation->repositoryUrl,
-                                    'package' => $buildInformation->packageName,
-                                    'sourceBranch' => $buildInformation->sourceBranch,
-                                    'targetBranch' => $buildInformation->targetBranchDirectory,
-                                    'bambooKey' => $buildTriggered->buildResultKey,
-                                    'user' => $userIdentifier,
-                                ])
-                        );
-                        $this->entityManager->flush();
+                        $historyService->writeHistory(new HistoryEntryDto(
+                            type: HistoryEntryType::DOCS_RENDERING,
+                            status: DocsRenderingHistoryStatus::TRIGGERED,
+                            triggeredBy: HistoryEntryTrigger::API,
+                            groupEntry: $buildTriggered->buildResultKey,
+                            data: [
+                                'repository' => $buildInformation->repositoryUrl,
+                                'package' => $buildInformation->packageName,
+                                'sourceBranch' => $buildInformation->sourceBranch,
+                                'targetBranch' => $buildInformation->targetBranchDirectory,
+                                'bambooKey' => $buildTriggered->buildResultKey,
+                                'user' => $userIdentifier,
+                            ]
+                        ));
                     }
                 } catch (ComposerJsonNotFoundException $e) {
                     // Repository did not provide a composer.json, or fetch failed
-                    $this->entityManager->persist(
-                        (new HistoryEntry())
-                        ->setType(HistoryEntryType::DOCS_RENDERING)
-                        ->setStatus(DocsRenderingHistoryStatus::NO_COMPOSER_JSON)
-                        ->setData([
-                            'type' => HistoryEntryType::DOCS_RENDERING,
-                            'status' => DocsRenderingHistoryStatus::NO_COMPOSER_JSON,
-                            'triggeredBy' => HistoryEntryTrigger::API,
+                    $historyService->writeHistory(new HistoryEntryDto(
+                        type: HistoryEntryType::DOCS_RENDERING,
+                        status: DocsRenderingHistoryStatus::NO_COMPOSER_JSON,
+                        triggeredBy: HistoryEntryTrigger::API,
+                        data: [
                             'exceptionCode' => $e->getCode(),
                             'exceptionMessage' => $e->getMessage(),
                             'repository' => $pushEvent->getRepositoryUrl(),
                             'composerFile' => $pushEvent->getUrlToComposerFile(),
                             'payload' => $request->getContent(),
                             'user' => $userIdentifier,
-                        ])
-                    );
-                    $this->entityManager->flush();
+                        ]
+                    ));
                     ++$erroredPushes;
                     $errorMessage = 'No composer.json found, invalid or unable to fetch. See https://intercept.typo3.com for more information.';
                     continue;
                 } catch (ComposerJsonInvalidException $e) {
-                    $this->entityManager->persist(
-                        (new HistoryEntry())
-                            ->setType(HistoryEntryType::DOCS_RENDERING)
-                            ->setStatus(DocsRenderingHistoryStatus::INVALID_COMPOSER_JSON)
-                            ->setData([
-                                'type' => HistoryEntryType::DOCS_RENDERING,
-                                'status' => DocsRenderingHistoryStatus::INVALID_COMPOSER_JSON,
-                                'triggeredBy' => HistoryEntryTrigger::API,
-                                'exceptionCode' => $e->getCode(),
-                                'exceptionMessage' => $e->getMessage(),
-                                'repository' => $pushEvent->getRepositoryUrl(),
-                                'composerFile' => $pushEvent->getUrlToComposerFile(),
-                                'payload' => $request->getContent(),
-                                'user' => $userIdentifier,
-                            ])
-                    );
-                    $this->entityManager->flush();
+                    $historyService->writeHistory(new HistoryEntryDto(
+                        type: HistoryEntryType::DOCS_RENDERING,
+                        status: DocsRenderingHistoryStatus::INVALID_COMPOSER_JSON,
+                        triggeredBy: HistoryEntryTrigger::API,
+                        data: [
+                            'exceptionCode' => $e->getCode(),
+                            'exceptionMessage' => $e->getMessage(),
+                            'repository' => $pushEvent->getRepositoryUrl(),
+                            'composerFile' => $pushEvent->getUrlToComposerFile(),
+                            'payload' => $request->getContent(),
+                            'user' => $userIdentifier,
+                        ]
+                    ));
                     ++$erroredPushes;
                     $errorMessage = 'Invalid composer.json. See https://intercept.typo3.com for more information.';
                     continue;
                 } catch (DocsPackageRegisteredWithDifferentRepositoryException $e) {
-                    $this->entityManager->persist(
-                        (new HistoryEntry())
-                        ->setType(HistoryEntryType::DOCS_RENDERING)
-                        ->setStatus(DocsRenderingHistoryStatus::PACKAGE_REGISTERED_WITH_DIFFERENT_REPOSITORY)
-                        ->setData([
-                            'type' => HistoryEntryType::DOCS_RENDERING,
-                            'status' => DocsRenderingHistoryStatus::PACKAGE_REGISTERED_WITH_DIFFERENT_REPOSITORY,
-                            'triggeredBy' => HistoryEntryTrigger::API,
+                    $historyService->writeHistory(new HistoryEntryDto(
+                        type: HistoryEntryType::DOCS_RENDERING,
+                        status: DocsRenderingHistoryStatus::PACKAGE_REGISTERED_WITH_DIFFERENT_REPOSITORY,
+                        triggeredBy: HistoryEntryTrigger::API,
+                        data: [
                             'exceptionCode' => $e->getCode(),
                             'exceptionMessage' => $e->getMessage(),
                             'repository' => $pushEvent->getRepositoryUrl(),
                             'package' => $e->getPackageName(),
                             'user' => $userIdentifier,
-                        ])
-                    );
-                    $this->entityManager->flush();
+                        ]
+                    ));
                     ++$erroredPushes;
                     $errorMessage = 'Package already registered for different repository. See https://intercept.typo3.com for more information.';
                     continue;
                 } catch (DocsPackageDoNotCareBranch $e) {
-                    $this->entityManager->persist(
-                        (new HistoryEntry())
-                            ->setType(HistoryEntryType::DOCS_RENDERING)
-                            ->setStatus(DocsRenderingHistoryStatus::NO_RELEVANT_BRANCH_OR_TAG)
-                            ->setData([
-                                'type' => HistoryEntryType::DOCS_RENDERING,
-                                'status' => DocsRenderingHistoryStatus::NO_RELEVANT_BRANCH_OR_TAG,
-                                'triggeredBy' => HistoryEntryTrigger::API,
-                                'exceptionCode' => $e->getCode(),
-                                'exceptionMessage' => $e->getMessage(),
-                                'repository' => $pushEvent->getRepositoryUrl(),
-                                'sourceBranch' => $pushEvent->getVersionString(),
-                                'user' => $userIdentifier,
-                            ])
-                    );
-                    $this->entityManager->flush();
+                    $historyService->writeHistory(new HistoryEntryDto(
+                        type: HistoryEntryType::DOCS_RENDERING,
+                        status: DocsRenderingHistoryStatus::NO_RELEVANT_BRANCH_OR_TAG,
+                        triggeredBy: HistoryEntryTrigger::API,
+                        data: [
+                            'exceptionCode' => $e->getCode(),
+                            'exceptionMessage' => $e->getMessage(),
+                            'repository' => $pushEvent->getRepositoryUrl(),
+                            'sourceBranch' => $pushEvent->getVersionString(),
+                            'user' => $userIdentifier,
+                        ]
+                    ));
                     ++$erroredPushes;
                     $errorMessage = 'Branch or tag name ignored for documentation rendering. See https://intercept.typo3.com for more information.';
                     continue;
                 } catch (DocsComposerMissingValueException $e) {
-                    $this->entityManager->persist(
-                        (new HistoryEntry())
-                            ->setType(HistoryEntryType::DOCS_RENDERING)
-                            ->setStatus(DocsRenderingHistoryStatus::MISSING_VALUE_IN_COMPOSER_JSON)
-                            ->setData([
-                                'type' => HistoryEntryType::DOCS_RENDERING,
-                                'status' => DocsRenderingHistoryStatus::MISSING_VALUE_IN_COMPOSER_JSON,
-                                'triggeredBy' => HistoryEntryTrigger::API,
-                                'exceptionCode' => $e->getCode(),
-                                'exceptionMessage' => $e->getMessage(),
-                                'repository' => $pushEvent->getRepositoryUrl(),
-                                'sourceBranch' => $pushEvent->getVersionString(),
-                                'user' => $userIdentifier,
-                            ])
-                    );
-                    $this->entityManager->flush();
+                    $historyService->writeHistory(new HistoryEntryDto(
+                        type: HistoryEntryType::DOCS_RENDERING,
+                        status: DocsRenderingHistoryStatus::MISSING_VALUE_IN_COMPOSER_JSON,
+                        triggeredBy: HistoryEntryTrigger::API,
+                        data: [
+                            'exceptionCode' => $e->getCode(),
+                            'exceptionMessage' => $e->getMessage(),
+                            'repository' => $pushEvent->getRepositoryUrl(),
+                            'sourceBranch' => $pushEvent->getVersionString(),
+                            'user' => $userIdentifier,
+                        ]
+                    ));
                     ++$erroredPushes;
                     $errorMessage = 'A mandatory value is missing in the composer.json. See https://intercept.typo3.com for more information.';
                     continue;
                 } catch (DocsComposerDependencyException $e) {
-                    $this->entityManager->persist(
-                        (new HistoryEntry())
-                            ->setType(HistoryEntryType::DOCS_RENDERING)
-                            ->setStatus(DocsRenderingHistoryStatus::CORE_DEPENDENCY_NOT_SET)
-                            ->setData([
-                                'type' => HistoryEntryType::DOCS_RENDERING,
-                                'status' => DocsRenderingHistoryStatus::CORE_DEPENDENCY_NOT_SET,
-                                'triggeredBy' => HistoryEntryTrigger::API,
-                                'exceptionCode' => $e->getCode(),
-                                'exceptionMessage' => $e->getMessage(),
-                                'repository' => $pushEvent->getRepositoryUrl(),
-                                'sourceBranch' => $pushEvent->getVersionString(),
-                                'user' => $userIdentifier,
-                            ])
-                    );
-                    $this->entityManager->flush();
+                    $historyService->writeHistory(new HistoryEntryDto(
+                        type: HistoryEntryType::DOCS_RENDERING,
+                        status: DocsRenderingHistoryStatus::CORE_DEPENDENCY_NOT_SET,
+                        triggeredBy: HistoryEntryTrigger::API,
+                        data: [
+                            'exceptionCode' => $e->getCode(),
+                            'exceptionMessage' => $e->getMessage(),
+                            'repository' => $pushEvent->getRepositoryUrl(),
+                            'sourceBranch' => $pushEvent->getVersionString(),
+                            'user' => $userIdentifier,
+                        ]
+                    ));
                     try {
                         $author = $composerAsObject->getFirstAuthor();
                         if (filter_var($author['email'] ?? '', FILTER_VALIDATE_EMAIL)) {
@@ -290,71 +250,55 @@ class DocsRenderingController extends AbstractController
             // Hook payload is a 'GitHub ping' - log that as 'info / success' with the
             // url that hook came from. This is triggered by GitHub when a new web hook is added,
             // we want to be nice and make this one succeed.
-            $this->entityManager->persist(
-                (new HistoryEntry())
-                    ->setType(HistoryEntryType::DOCS_RENDERING)
-                    ->setStatus(DocsRenderingHistoryStatus::GITHUB_PING)
-                    ->setData([
-                        'type' => HistoryEntryType::DOCS_RENDERING,
-                        'status' => DocsRenderingHistoryStatus::GITHUB_PING,
-                        'triggeredBy' => HistoryEntryTrigger::API,
-                        'repository' => $e->getRepositoryUrl(),
-                    ])
-            );
-            $this->entityManager->flush();
+            $historyService->writeHistory(new HistoryEntryDto(
+                type: HistoryEntryType::DOCS_RENDERING,
+                status: DocsRenderingHistoryStatus::GITHUB_PING,
+                triggeredBy: HistoryEntryTrigger::API,
+                data: [
+                    'repository' => $e->getRepositoryUrl(),
+                ]
+            ));
 
             return new Response('Received github ping. Please push content to the repository to render some documentation. See https://intercept.typo3.com for more information.');
         } catch (UnsupportedWebHookRequestException $e) {
             // Hook payload could not be identified as hook that should trigger rendering
-            $this->entityManager->persist(
-                (new HistoryEntry())
-                    ->setType(HistoryEntryType::DOCS_RENDERING)
-                    ->setStatus(DocsRenderingHistoryStatus::UNSUPPORTED_HOOK)
-                    ->setData([
-                        'type' => HistoryEntryType::DOCS_RENDERING,
-                        'status' => DocsRenderingHistoryStatus::UNSUPPORTED_HOOK,
-                        'headers' => $request->headers,
-                        'payload' => $request->getContent(),
-                        'triggeredBy' => HistoryEntryTrigger::API,
-                        'exceptionCode' => $e->getCode(),
-                        'user' => $userIdentifier,
-                    ])
-            );
-            $this->entityManager->flush();
+            $historyService->writeHistory(new HistoryEntryDto(
+                type: HistoryEntryType::DOCS_RENDERING,
+                status: DocsRenderingHistoryStatus::UNSUPPORTED_HOOK,
+                triggeredBy: HistoryEntryTrigger::API,
+                data: [
+                    'headers' => $request->headers,
+                    'payload' => $request->getContent(),
+                    'exceptionCode' => $e->getCode(),
+                    'user' => $userIdentifier,
+                ]
+            ));
 
             return new Response('Invalid hook payload. See https://intercept.typo3.com for more information.', Response::HTTP_PRECONDITION_FAILED);
         } catch (GitBranchDeletedException $e) {
-            $this->entityManager->persist(
-                (new HistoryEntry())
-                    ->setType(HistoryEntryType::DOCS_RENDERING)
-                    ->setStatus(DocsRenderingHistoryStatus::BRANCH_DELETED)
-                    ->setData([
-                        'type' => HistoryEntryType::DOCS_RENDERING,
-                        'status' => DocsRenderingHistoryStatus::BRANCH_DELETED,
-                        'triggeredBy' => HistoryEntryTrigger::API,
-                        'exceptionCode' => $e->getCode(),
-                        'exceptionMessage' => $e->getMessage(),
-                        'user' => $userIdentifier,
-                    ])
-            );
-            $this->entityManager->flush();
+            $historyService->writeHistory(new HistoryEntryDto(
+                type: HistoryEntryType::DOCS_RENDERING,
+                status: DocsRenderingHistoryStatus::BRANCH_DELETED,
+                triggeredBy: HistoryEntryTrigger::API,
+                data: [
+                    'exceptionCode' => $e->getCode(),
+                    'exceptionMessage' => $e->getMessage(),
+                    'user' => $userIdentifier,
+                ]
+            ));
 
             return new Response('The branch in this push event has been deleted.', Response::HTTP_PRECONDITION_FAILED);
         } catch (DocsNoRstChangesException $e) {
-            $this->entityManager->persist(
-                (new HistoryEntry())
-                    ->setType(HistoryEntryType::DOCS_RENDERING)
-                    ->setStatus(DocsRenderingHistoryStatus::BRANCH_NO_RST_CHANGES)
-                    ->setData([
-                        'type' => HistoryEntryType::DOCS_RENDERING,
-                        'status' => DocsRenderingHistoryStatus::BRANCH_NO_RST_CHANGES,
-                        'triggeredBy' => HistoryEntryTrigger::API,
-                        'exceptionCode' => $e->getCode(),
-                        'exceptionMessage' => $e->getMessage(),
-                        'user' => $userIdentifier,
-                    ])
-            );
-            $this->entityManager->flush();
+            $historyService->writeHistory(new HistoryEntryDto(
+                type: HistoryEntryType::DOCS_RENDERING,
+                status: DocsRenderingHistoryStatus::BRANCH_NO_RST_CHANGES,
+                triggeredBy: HistoryEntryTrigger::API,
+                data: [
+                    'exceptionCode' => $e->getCode(),
+                    'exceptionMessage' => $e->getMessage(),
+                    'user' => $userIdentifier,
+                ]
+            ));
 
             return new Response(null, Response::HTTP_NO_CONTENT);
         }

--- a/src/Dto/HistoryEntryDto.php
+++ b/src/Dto/HistoryEntryDto.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package t3g/intercept.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Dto;
+
+final readonly class HistoryEntryDto
+{
+    public function __construct(
+        public string $type,
+        public string $status,
+        public string $triggeredBy,
+        public ?string $groupEntry = null,
+        public array $data = [],
+    ) {
+    }
+}

--- a/src/Service/HistoryService.php
+++ b/src/Service/HistoryService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package t3g/intercept.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Service;
+
+use App\Dto\HistoryEntryDto;
+use App\Entity\HistoryEntry;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class HistoryService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function writeHistory(HistoryEntryDto $historyEntryDto): HistoryEntry
+    {
+        $data = $historyEntryDto->data;
+
+        // Unsetting values in incoming data to ensure they are stored properly on top with the upcoming array_merge()
+        unset($data['type'], $data['status'], $data['triggeredBy']);
+
+        $data = array_merge([
+            'type' => $historyEntryDto->type,
+            'status' => $historyEntryDto->status,
+            'triggeredBy' => $historyEntryDto->triggeredBy,
+        ], $data);
+
+        $historyEntry = (new HistoryEntry())
+            ->setType($historyEntryDto->type)
+            ->setStatus($historyEntryDto->status)
+            ->setData($data);
+        if ('' !== (string) $historyEntryDto->groupEntry) {
+            $historyEntry->setGroupEntry($historyEntryDto->groupEntry);
+        }
+
+        $this->entityManager->persist($historyEntry);
+        $this->entityManager->flush();
+
+        return $historyEntry;
+    }
+}

--- a/src/Service/RenderDocumentationService.php
+++ b/src/Service/RenderDocumentationService.php
@@ -11,15 +11,16 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Dto\HistoryEntryDto;
 use App\Entity\DocumentationJar;
-use App\Entity\HistoryEntry;
 use App\Enum\DocsRenderingHistoryStatus;
 use App\Enum\DocumentationStatus;
+use App\Enum\HistoryEntryType;
 use App\Exception\DocsPackageDoNotCareBranch;
 use App\Exception\DuplicateDocumentationRepositoryException;
 use App\Extractor\DeploymentInformation;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use T3G\Bundle\Keycloak\Security\KeyCloakUser;
 
 class RenderDocumentationService
@@ -27,9 +28,9 @@ class RenderDocumentationService
     public function __construct(
         protected DocumentationBuildInformationService $documentationBuildInformationService,
         protected GithubService $githubService,
+        protected HistoryService $historyService,
         protected LoggerInterface $logger,
-        protected EntityManagerInterface $entityManager,
-        protected \Symfony\Bundle\SecurityBundle\Security $security
+        protected Security $security
     ) {
     }
 
@@ -52,24 +53,20 @@ class RenderDocumentationService
         if ($user instanceof KeyCloakUser) {
             $userIdentifier = $user->getDisplayName();
         }
-        $this->entityManager->persist(
-            (new HistoryEntry())
-                ->setType('docsRendering')
-                ->setStatus('triggered')
-                ->setGroupEntry($buildTriggered->buildResultKey)
-                ->setData([
-                    'type' => 'docsRendering',
-                    'status' => DocsRenderingHistoryStatus::TRIGGERED,
-                    'triggeredBy' => $scope,
-                    'repository' => $buildInformation->repositoryUrl,
-                    'package' => $buildInformation->packageName,
-                    'sourceBranch' => $buildInformation->sourceBranch,
-                    'targetBranch' => $buildInformation->targetBranchDirectory,
-                    'bambooKey' => $buildTriggered->buildResultKey,
-                    'user' => $userIdentifier,
-                ])
-        );
-        $this->entityManager->flush();
+        $this->historyService->writeHistory(new HistoryEntryDto(
+            type: HistoryEntryType::DOCS_RENDERING,
+            status: DocsRenderingHistoryStatus::TRIGGERED,
+            triggeredBy: $scope,
+            groupEntry: $buildTriggered->buildResultKey,
+            data: [
+                'repository' => $buildInformation->repositoryUrl,
+                'package' => $buildInformation->packageName,
+                'sourceBranch' => $buildInformation->sourceBranch,
+                'targetBranch' => $buildInformation->targetBranchDirectory,
+                'bambooKey' => $buildTriggered->buildResultKey,
+                'user' => $userIdentifier,
+            ]
+        ));
 
         return $buildInformation;
     }

--- a/tests/Functional/Service/HistoryServiceTest.php
+++ b/tests/Functional/Service/HistoryServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package t3g/intercept.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Service;
+
+use App\Dto\HistoryEntryDto;
+use App\Service\HistoryService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use T3G\LibTestHelper\Database\DatabasePrimer;
+
+final class HistoryServiceTest extends KernelTestCase
+{
+    use DatabasePrimer;
+
+    private HistoryService $historyService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+        $this->prime();
+        $this->historyService = self::getContainer()->get(HistoryService::class);
+    }
+
+    public static function writeHistoryDataProvider(): \Generator
+    {
+        yield [
+            'type' => 'history_type',
+            'status' => 'history_status',
+            'triggeredBy' => 'API',
+            'groupEntry' => null,
+            'data' => [
+                'foo' => 'bar',
+                'baz' => 'bencer',
+                'answer' => 42,
+            ],
+            'expectedData' => [
+                'type' => 'history_type',
+                'status' => 'history_status',
+                'triggeredBy' => 'API',
+                'foo' => 'bar',
+                'baz' => 'bencer',
+                'answer' => 42,
+            ],
+        ];
+
+        yield [
+            'type' => 'history_type',
+            'status' => 'history_status',
+            'triggeredBy' => 'API',
+            'groupEntry' => 'Grouped entry',
+            'data' => [
+                'type' => 'ignored_type',
+                'status' => 'ignored_status',
+                'triggeredBy' => 'ignored_trigger',
+                'foo' => 'bar',
+                'baz' => 'bencer',
+                'answer' => 42,
+            ],
+            'expectedData' => [
+                'type' => 'history_type',
+                'status' => 'history_status',
+                'triggeredBy' => 'API',
+                'foo' => 'bar',
+                'baz' => 'bencer',
+                'answer' => 42,
+            ],
+        ];
+    }
+
+    #[DataProvider('writeHistoryDataProvider')]
+    #[Test]
+    public function writeHistory(string $type, string $status, string $triggeredBy, ?string $groupEntry, array $data, array $expectedData): void
+    {
+        $historyEntry = $this->historyService->writeHistory(new HistoryEntryDto(
+            type: $type,
+            status: $status,
+            triggeredBy: $triggeredBy,
+            groupEntry: $groupEntry,
+            data: $data
+        ));
+
+        $expectedGroupEntry = $groupEntry ?? 'default';
+
+        $this->assertSame($type, $historyEntry->getType());
+        $this->assertSame($status, $historyEntry->getStatus());
+        $this->assertSame($expectedGroupEntry, $historyEntry->getGroupEntry());
+        $this->assertSame($expectedData, $historyEntry->getData());
+    }
+}


### PR DESCRIPTION
A new `HistoryService` is added whose single purpose is to write history entries into the database.

This is a first change in a series of refactorings.